### PR TITLE
simplify landing page

### DIFF
--- a/source/OVERVIEW.rst
+++ b/source/OVERVIEW.rst
@@ -21,8 +21,6 @@ Jupyter Notebooks and Markdown files into publishable content.
 Providing online-executable runtimes and a powerful data caching system, NeuroLibre makes a **groundbreaking preprint
 server where you can plant the seeds of living publications.**
 
-.. seealso:: Before submitting: please read our `submission guidelines <https://docs.neurolibre.com/en/latest/SUBMIT.html>`_.
-
 As an author and before submitting, you:
 
 1. Create a github repository with notebooks that you would like to share.


### PR DESCRIPTION
Currently the landing page of the docs has a "see also" text box that links to the same docs. 
It is confusing as a reader, and not really useful: the user is already reading the docs, and does not need a link to progress to the next section at the top of the landing page.
I suggest to simply remove the box, unless I am missing something. 